### PR TITLE
Updated email_regex

### DIFF
--- a/lib/StandalonePHPEnkoder.php
+++ b/lib/StandalonePHPEnkoder.php
@@ -75,7 +75,7 @@ class StandalonePHPEnkoder {
   private $enkodings;
 
   public function __construct() {
-    $this->email_regex = '[\w\d+_.-]+@(?:[\w\d_-]+\.)+[\w]{2,18}';
+    $this->email_regex = '^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$';
     // First matching group specifies banned first characters
     // Second matching group excludes email address preceded by =" i.e. src="img@2x.gif"
     $this->ptext_email = '/(?<=[^\/\w\d\+_.:-])(?<!=")(' . $this->email_regex . ')/i';


### PR DESCRIPTION
The regex fails when there are special characters ```(!#$%&'*+-/=?^_\`{|}~)``` in the email address.
So I've updated `email_regex` to account for that.